### PR TITLE
Fix coverage token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,3 @@ bin/
 tmp/
 
 # Generated assets
-
-# Infra
-.cico-prepare

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -58,7 +58,7 @@ function run_tests_with_coverage() {
 
   # Upload coverage to codecov.io
   cp tmp/coverage.mode* coverage.txt
-  bash <(curl -s https://codecov.io/bash) -X search -f coverage.txt -t 6539a1b6-70f9-4ba1-8ab5-d1c8a104ec83 #-X fix
+  bash <(curl -s https://codecov.io/bash) -X search -f coverage.txt -t 3df1c77b-5c96-4072-831f-9eabdaf2cb12
 
   echo "CICO: ran tests and uploaded coverage"
 }


### PR DESCRIPTION
Addressing @kwk's comment: https://github.com/redhat-developer/devopsconsole-operator/pull/15#discussion_r263243514

Removing cico-prepare from gitignore as it is no longer being created/used