### PR TITLE
Component controller should watch all namespaces

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -10,7 +10,6 @@ import (
 	appsv1 "github.com/openshift/api/apps/v1"
 	buildv1 "github.com/openshift/api/build/v1"
 	imagev1 "github.com/openshift/api/image/v1"
-	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/ready"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
@@ -41,12 +40,6 @@ func main() {
 	logf.SetLogger(logf.ZapLogger(false))
 
 	printVersion()
-
-	namespace, err := k8sutil.GetWatchNamespace()
-	if err != nil {
-		log.Error(err, "failed to get watch namespace")
-		os.Exit(1)
-	}
 
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -77,7 +77,7 @@ func main() {
 	}()
 
 	// Create a new Cmd to provide shared dependencies and start components
-	mgr, err := manager.New(cfg, manager.Options{Namespace: namespace})
+	mgr, err := manager.New(cfg, manager.Options{})
 	if err != nil {
 		log.Error(err, "")
 		os.Exit(1)


### PR DESCRIPTION
This PR changes the `manager.Options` value to set `namespace` to `''`.
With this change, the component operator will watch all namespaces.