### PR TITLE
Use builder image from the openshift namespace

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -292,6 +292,20 @@
   version = "1.0.1"
 
 [[projects]]
+  digest = "1:8bc8f43d2332d035857c92581df240f247c287629d5f60c751df609f9b6215c5"
+  name = "github.com/openshift/api"
+  packages = [
+    "apps/v1",
+    "build/v1",
+    "image/docker10",
+    "image/dockerpre012",
+    "image/v1",
+  ]
+  pruneopts = "NT"
+  revision = "0d921e363e951d89f583292c60d013c318df64dc"
+  version = "v3.9.0"
+
+[[projects]]
   digest = "1:b186c2fcf87d05c5129ad0d89ea062853b0bdf6d6bca1ed4a22157962f2ad8dd"
   name = "github.com/operator-framework/operator-sdk"
   packages = [
@@ -704,6 +718,7 @@
     "rest",
     "rest/watch",
     "restmapper",
+    "testing",
     "third_party/forked/golang/template",
     "tools/auth",
     "tools/cache",
@@ -812,6 +827,7 @@
     "pkg/client",
     "pkg/client/apiutil",
     "pkg/client/config",
+    "pkg/client/fake",
     "pkg/controller",
     "pkg/controller/controllerutil",
     "pkg/event",
@@ -843,11 +859,14 @@
   analyzer-version = 1
   input-imports = [
     "github.com/go-openapi/spec",
-    "github.com/operator-framework/operator-sdk/pkg/k8sutil",
+    "github.com/openshift/api/apps/v1",
+    "github.com/openshift/api/build/v1",
+    "github.com/openshift/api/image/v1",
     "github.com/operator-framework/operator-sdk/pkg/leader",
     "github.com/operator-framework/operator-sdk/pkg/ready",
     "github.com/operator-framework/operator-sdk/pkg/test",
     "github.com/operator-framework/operator-sdk/version",
+    "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/api/errors",
@@ -855,6 +874,7 @@
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/apimachinery/pkg/types",
+    "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/code-generator/cmd/client-gen",
     "k8s.io/code-generator/cmd/conversion-gen",
@@ -867,6 +887,7 @@
     "k8s.io/kube-openapi/pkg/common",
     "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/config",
+    "sigs.k8s.io/controller-runtime/pkg/client/fake",
     "sigs.k8s.io/controller-runtime/pkg/controller",
     "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil",
     "sigs.k8s.io/controller-runtime/pkg/handler",

--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,7 @@ deploy-rbac:
 ## Deploy CRD
 deploy-crd:
 	@-oc apply -f deploy/crds/devopsconsole_v1alpha1_component_crd.yaml
-	@-oc apply -f deploy/crds/devopsconsole_v1alpha1_envdeployment_crd.yaml
+	@-oc apply -f deploy/crds/devopsconsole_v1alpha1_gitsource_crd.yaml
 
 .PHONY: deploy-operator
 ## Deploy Operator

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ minishift profile set devopsconsole
 minishift addon enable admin-user
 ```
 * optionally, configure the VM 
+
 ```
 minishift config set cpus 4
 minishift config set memory 8GB
@@ -94,6 +95,7 @@ Please consult [the documentation](https://github.com/operator-framework/operato
 | Gopkg.toml Gopkg.lock | The [dep](https://github.com/golang/dep) manifests that describe the external dependencies of this operator.|
 | vendor | The golang [Vendor](https://golang.org/cmd/go/#hdr-Vendor_Directories) folder that contains the local copies of the external dependencies that satisfy the imports of this project. [dep](https://github.com/golang/dep) manages the vendor directly.|
 
+
 ## Enabling the DevOps perspective in OpenShift
 
 The frontend can check for the presence of the DevOpsConsole CRDs using the Kubernetes API.  Check for [the existence of a Custom Resource Definitions](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#list-customresourcedefinition-v1beta1-apiextensions) with name as `gitsources.devopsconsole.openshift.io`.  If it exists, it will enable the DevOps perspective in the Openshift Console.
@@ -137,3 +139,4 @@ spec:
 [go_tool]:https://golang.org/dl/
 [docker_tool]:https://docs.docker.com/install/
 [kubectl_tool]:https://kubernetes.io/docs/tasks/tools/install-kubectl/
+

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -85,6 +85,7 @@ func main() {
 	log.Info("Registering Components.")
 
 	// Setup Scheme for all resources
+	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "")
 		os.Exit(1)

--- a/deploy/crds/devopsconsole_v1alpha1_gitsource_crd.yaml
+++ b/deploy/crds/devopsconsole_v1alpha1_gitsource_crd.yaml
@@ -10,7 +10,7 @@ spec:
     plural: gitsources
     singular: gitsource
     shortNames:
-      - gitsrc
+    - gitsrc
   scope: Namespaced
   validation:
     # openAPIV3Schema is the schema for validating custom objects.

--- a/make/test.mk
+++ b/make/test.mk
@@ -250,7 +250,7 @@ gocov-unit-annotate: prebuild-check $(GOCOV_BIN) $(COV_PATH_UNIT)
 #
 # Parameters:
 #  1. Test name (e.g. "unit" or "integration")
-#  2. package name "github.com/fabric8-services/fabric8-auth/model"
+#  2. package name "github.com/redhat-developer/devopsconsole-operator/pgk/controller/component"
 #  3. File in which to combine the output
 #  4. Path to file in which to store names of packages that failed testing
 #  5. Environment variable (in the form VAR=VALUE) to be specified for running

--- a/pkg/apis/addtoscheme_devopsconsole_v1alpha1.go
+++ b/pkg/apis/addtoscheme_devopsconsole_v1alpha1.go
@@ -1,7 +1,7 @@
 package apis
 
 import (
-	"github.com/redhat-developer/devopsconsole-operator/pkg/apis/devopsconsole/v1alpha1"
+	"github.com/redhat-developer/devopsconsole-operator/pkg/apis/devopsconsole-operator/v1alpha1"
 )
 
 func init() {

--- a/pkg/apis/devopsconsole/v1alpha1/component_types.go
+++ b/pkg/apis/devopsconsole/v1alpha1/component_types.go
@@ -8,9 +8,9 @@ import (
 // +k8s:openapi-gen=true
 type ComponentSpec struct {
 	// Container image use to build (nodejs, golang etc..)
-	BuildType	string	`json:"buildType"`
+	BuildType string `json:"buildType"`
 	// Codebase is the source code of your component. Atm only public remote URL are supported.
-	Codebase   	string `json:"codebase"`
+	Codebase string `json:"codebase"`
 }
 
 // ComponentStatus defines the observed state of Component

--- a/pkg/controller/component/component_controller.go
+++ b/pkg/controller/component/component_controller.go
@@ -163,7 +163,7 @@ func (r *ReconcileComponent) getBuilderImage(instance *componentsv1alpha1.Compon
 	found := &imagev1.ImageStream{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: instance.Spec.BuildType, Namespace: openshiftNamespace}, found)
 	if err != nil {
-		log.Info(fmt.Sprintf("** Searching in namespace %s imagestream %s fails **"), openshiftNamespace, instance.Spec.BuildType)
+		log.Info(fmt.Sprintf("** Searching in namespace %s imagestream %s fails **", openshiftNamespace, instance.Spec.BuildType))
 		// Create an empty image name "nodejs-runtime"
 		newImageForRuntime = newImageStreamFromDocker(instance.Namespace, instance.Name, instance.Spec.BuildType)
 		if newImageForRuntime == nil {

--- a/pkg/controller/component/component_controller.go
+++ b/pkg/controller/component/component_controller.go
@@ -130,7 +130,7 @@ func (r *ReconcileComponent) Reconcile(request reconcile.Request) (reconcile.Res
 			log.Error(err, "** Setting owner reference fails **")
 			return reconcile.Result{}, err
 		}
-		// Create a build image named either "myapp-builder" or reuse openshift "nodejs" builder image
+		// Create a build image named either "myapp-builder" or reuse openshift's builder image
 		ir, err := r.getBuilderImage(instance)
 		if err != nil {
 			log.Error(err, "** ImageStream builder creation fails **")
@@ -164,7 +164,7 @@ func (r *ReconcileComponent) getBuilderImage(instance *componentsv1alpha1.Compon
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: instance.Spec.BuildType, Namespace: openshiftNamespace}, found)
 	if err != nil {
 		log.Info(fmt.Sprintf("** Searching in namespace %s imagestream %s fails **", openshiftNamespace, instance.Spec.BuildType))
-		// Create an empty image name "nodejs-builder"
+		// Create an empty image name "<BuildType>-builder"
 		newImageForBuilder = newImageStreamFromDocker(instance.Namespace, instance.Name, instance.Spec.BuildType)
 		if newImageForBuilder == nil {
 			log.Error(err, "** Creating new BUILDER image fails **")
@@ -184,7 +184,7 @@ func (r *ReconcileComponent) getBuilderImage(instance *componentsv1alpha1.Compon
 		builderName = instance.Name + "-builder"
 		builderNamespace = instance.Namespace
 	} else {
-		log.Info("** nodejs' openshift namespace imagestream found **")
+		log.Info("** Found openshift's imagestream to use as builder **")
 		newImageForBuilder = found
 		builderName = newImageForBuilder.Name
 		builderNamespace = newImageForBuilder.Namespace

--- a/pkg/controller/component/component_controller.go
+++ b/pkg/controller/component/component_controller.go
@@ -8,7 +8,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"strconv"
 	componentsv1alpha1 "github.com/redhat-developer/devopsconsole-operator/pkg/apis/devopsconsole/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+	"strconv"
 
 	buildv1 "github.com/openshift/api/build/v1"
 	imagev1 "github.com/openshift/api/image/v1"
@@ -62,7 +62,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 var (
 	_                  reconcile.Reconciler = &ReconcileComponent{}
-	buildTypeImages                        = map[string]string{"nodejs": "nodeshift/centos7-s2i-nodejs:10.x"}
+	buildTypeImages                         = map[string]string{"nodejs": "nodeshift/centos7-s2i-nodejs:10.x"}
 	openshiftNamespace                      = "openshift"
 )
 
@@ -152,7 +152,7 @@ func (r *ReconcileComponent) Reconcile(request reconcile.Request) (reconcile.Res
 
 type builderImage struct {
 	namespace string
-	name string
+	name      string
 }
 
 func (r *ReconcileComponent) getBuilderImage(instance *componentsv1alpha1.Component) (*builderImage, error) {
@@ -189,7 +189,7 @@ func (r *ReconcileComponent) getBuilderImage(instance *componentsv1alpha1.Compon
 		builderName = newImageForBuilder.Name
 		builderNamespace = newImageForBuilder.Namespace
 	}
-	return &builderImage{namespace: builderNamespace, name: builderName }, nil
+	return &builderImage{namespace: builderNamespace, name: builderName}, nil
 }
 
 func newImageStreamFromDocker(namespace string, name string, buildType string) *imagev1.ImageStream {

--- a/pkg/controller/component/component_controller_test.go
+++ b/pkg/controller/component/component_controller_test.go
@@ -16,10 +16,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"testing"
 )
+
 const (
-	Name = "MyComp"
+	Name      = "MyComp"
 	Namespace = "test-project"
 )
+
 // TestComponentController runs Component.Reconcile() against a
 // fake client that tracks a Component object.
 func TestComponentController(t *testing.T) {
@@ -29,12 +31,12 @@ func TestComponentController(t *testing.T) {
 	// A Component resource with metadata and spec.
 	cp := &compv1alpha1.Component{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: Name,
+			Name:      Name,
 			Namespace: Namespace,
-	    },
+		},
 		Spec: compv1alpha1.ComponentSpec{
 			BuildType: "nodejs",
-			Codebase: "https://somegit.con/myrepo",
+			Codebase:  "https://somegit.con/myrepo",
 		},
 	}
 
@@ -88,7 +90,7 @@ func TestComponentController(t *testing.T) {
 		isBuilder := &imagev1.ImageStream{}
 		errGetBuilderImage := cl.Get(context.Background(), types.NamespacedName{Namespace: Namespace, Name: Name + "-builder"}, isBuilder)
 		require.NoError(t, errGetBuilderImage, "builder imagestream is not created")
-		require.Equal(t, isBuilder.ObjectMeta.Name, Name + "-builder", "imagestream builder shoulbe name with pattern CR's name append with -builder")
+		require.Equal(t, isBuilder.ObjectMeta.Name, Name+"-builder", "imagestream builder shoulbe name with pattern CR's name append with -builder")
 		require.Equal(t, isBuilder.ObjectMeta.Namespace, Namespace, "")
 		require.Equal(t, len(isBuilder.Labels), 1, "imagestream builder should contain one label")
 		require.Equal(t, isBuilder.Labels["app"], Name, "imagestream builder should have one label with name of CR.")
@@ -98,24 +100,24 @@ func TestComponentController(t *testing.T) {
 		require.Equal(t, isBuilder.Spec.Tags[0].From.Name, "nodeshift/centos7-s2i-nodejs:10.x", "imagestream builder should be taken from nodeshift/centos7-s2i-nodejs:10.x")
 
 		bc := &buildv1.BuildConfig{}
-		errGetBC := cl.Get(context.Background(), types.NamespacedName{Namespace:Namespace, Name: Name  + "-bc"}, bc)
+		errGetBC := cl.Get(context.Background(), types.NamespacedName{Namespace: Namespace, Name: Name + "-bc"}, bc)
 		require.NoError(t, errGetBC, "build config is not created")
 		require.Equal(t, "https://somegit.con/myrepo", bc.Spec.Source.Git.URI, "build config should not have any source attached")
 		require.Equal(t, 2, len(bc.Spec.Triggers), "build config contains 2 triggers")
 		require.Equal(t, buildv1.ConfigChangeBuildTriggerType, bc.Spec.Triggers[0].Type, "build config should be triggered on config change")
 		require.Equal(t, buildv1.ImageChangeBuildTriggerType, bc.Spec.Triggers[1].Type, "build config should be triggered on image change")
 		require.Equal(t, 1, len(bc.Labels), "bc should contain one label")
-		require.Equal(t, Name + "-bc", bc.ObjectMeta.Labels["app"], "bc builder should have one label with name of CR.")
+		require.Equal(t, Name+"-bc", bc.ObjectMeta.Labels["app"], "bc builder should have one label with name of CR.")
 	})
 
 	t.Run("with ReconcileComponent CR containing all required field and buildtype matches openshift namespace imagestream", func(t *testing.T) {
 		//given
 		isNodejs := &imagev1.ImageStream{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "nodejs",
+				Name:      "nodejs",
 				Namespace: "openshift",
 			},
-			Spec:imagev1.ImageStreamSpec{},
+			Spec: imagev1.ImageStreamSpec{},
 		}
 		// Objects to track in the fake client.
 		objs := []runtime.Object{
@@ -154,7 +156,7 @@ func TestComponentController(t *testing.T) {
 		require.Error(t, errGetBuilderImage, "builder imagestream should not be created")
 
 		bc := &buildv1.BuildConfig{}
-		errGetBC := cl.Get(context.Background(), types.NamespacedName{Namespace:Namespace, Name: Name  + "-bc"}, bc)
+		errGetBC := cl.Get(context.Background(), types.NamespacedName{Namespace: Namespace, Name: Name + "-bc"}, bc)
 		require.NoError(t, errGetBC, "build config is not created")
 		require.Equal(t, "https://somegit.con/myrepo", bc.Spec.Source.Git.URI, "build config should not have any source attached")
 		require.Equal(t, 2, len(bc.Spec.Triggers), "build config contains 2 triggers")
@@ -163,7 +165,7 @@ func TestComponentController(t *testing.T) {
 		require.Equal(t, "openshift", bc.Spec.CommonSpec.Strategy.SourceStrategy.From.Namespace, "builder image used in build config should be taken from openshift namespace")
 		require.Equal(t, "nodejs:latest", bc.Spec.CommonSpec.Strategy.SourceStrategy.From.Name, "builder image used in build config should be taken from openshift's nodejs image")
 		require.Equal(t, 1, len(bc.Labels), "bc should contain one label")
-		require.Equal(t, Name + "-bc", bc.ObjectMeta.Labels["app"], "bc builder should have one label with name of CR.")
+		require.Equal(t, Name+"-bc", bc.ObjectMeta.Labels["app"], "bc builder should have one label with name of CR.")
 	})
 
 	t.Run("with ReconcileComponent CR without buildtype", func(t *testing.T) {
@@ -175,7 +177,6 @@ func TestComponentController(t *testing.T) {
 		cp.Spec.Codebase = "https://somegit.con/myrepo"
 		// Create a fake client to mock API calls.
 		cl := fake.NewFakeClient(objs...)
-
 
 		// Create a ReconcileComponent object with the scheme and fake client.
 		r := &ReconcileComponent{client: cl, scheme: s}
@@ -207,7 +208,7 @@ func TestComponentController(t *testing.T) {
 		require.Equal(t, errors.ReasonForError(errGetBuilderImage), metav1.StatusReasonNotFound, "bc could not found associated imagestream ")
 
 		bc := &buildv1.BuildConfig{}
-		errGetBC := cl.Get(context.Background(), types.NamespacedName{Namespace:Namespace, Name: Name  + "-bc"}, bc)
+		errGetBC := cl.Get(context.Background(), types.NamespacedName{Namespace: Namespace, Name: Name + "-bc"}, bc)
 		require.Error(t, errGetBC, "build config should not not created with missing CR's buildtype")
 		require.Equal(t, errors.ReasonForError(errGetBC), metav1.StatusReasonNotFound, "bc could not found associated imagestream ")
 	})
@@ -221,7 +222,6 @@ func TestComponentController(t *testing.T) {
 		cp.Spec.Codebase = ""
 		// Create a fake client to mock API calls.
 		cl := fake.NewFakeClient(objs...)
-
 
 		// Create a ReconcileComponent object with the scheme and fake client.
 		r := &ReconcileComponent{client: cl, scheme: s}
@@ -252,7 +252,7 @@ func TestComponentController(t *testing.T) {
 		require.NoError(t, errGetBuilderImage, "builder imagestream is not created")
 
 		bc := &buildv1.BuildConfig{}
-		errGetBC := cl.Get(context.Background(), types.NamespacedName{Namespace:Namespace, Name: Name  + "-bc"}, bc)
+		errGetBC := cl.Get(context.Background(), types.NamespacedName{Namespace: Namespace, Name: Name + "-bc"}, bc)
 		require.NoError(t, errGetBC, "buildconfig is not created")
 		require.Equal(t, "", bc.Spec.Source.Git.URI, "build config should not have any source attached")
 	})

--- a/pkg/controller/component/component_controller_test.go
+++ b/pkg/controller/component/component_controller_test.go
@@ -7,6 +7,7 @@ import (
 	compv1alpha1 "github.com/redhat-developer/devopsconsole-operator/pkg/apis/devopsconsole/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -84,9 +85,9 @@ func TestComponentController(t *testing.T) {
 		errGetImage := cl.Get(context.Background(), types.NamespacedName{Namespace: Namespace, Name: Name + "-output"}, is)
 		require.NoError(t, errGetImage, "output imagestream is not created")
 
-		isRuntime := &imagev1.ImageStream{}
-		errGetRuntimeImage := cl.Get(context.Background(), types.NamespacedName{Namespace: Namespace, Name: Name + "-runtime"}, isRuntime)
-		require.NoError(t, errGetRuntimeImage, "runtime imagestream is not created")
+		isBuilder := &imagev1.ImageStream{}
+		errGetBuilderImage := cl.Get(context.Background(), types.NamespacedName{Namespace: Namespace, Name: Name + "-runtime"}, isBuilder)
+		require.NoError(t, errGetBuilderImage, "builder imagestream is not created")
 
 		bc := &buildv1.BuildConfig{}
 		errGetBC := cl.Get(context.Background(), types.NamespacedName{Namespace:Namespace, Name: Name  + "-bc"}, bc)
@@ -129,13 +130,15 @@ func TestComponentController(t *testing.T) {
 		errGetImage := cl.Get(context.Background(), types.NamespacedName{Namespace: Namespace, Name: Name + "-output"}, is)
 		require.NoError(t, errGetImage, "output imagestream is not created")
 
-		isRuntime := &imagev1.ImageStream{}
-		errGetRuntimeImage := cl.Get(context.Background(), types.NamespacedName{Namespace: Namespace, Name: Name + "-runtime"}, isRuntime)
-		require.Error(t, errGetRuntimeImage, "runtime imagestream should not be created with missing CR's buildtype")
+		isBuilder := &imagev1.ImageStream{}
+		errGetBuilderImage := cl.Get(context.Background(), types.NamespacedName{Namespace: Namespace, Name: Name + "-runtime"}, isBuilder)
+		require.Error(t, errGetBuilderImage, "builder imagestream should not be created with missing CR's buildtype")
+		require.Equal(t, errors.ReasonForError(errGetBuilderImage), metav1.StatusReasonNotFound, "bc could not found associated imagestream ")
 
 		bc := &buildv1.BuildConfig{}
 		errGetBC := cl.Get(context.Background(), types.NamespacedName{Namespace:Namespace, Name: Name  + "-bc"}, bc)
 		require.Error(t, errGetBC, "build config should not not created with missing CR's buildtype")
+		require.Equal(t, errors.ReasonForError(errGetBC), metav1.StatusReasonNotFound, "bc could not found associated imagestream ")
 	})
 
 	t.Run("with ReconcileComponent CR without codebases", func(t *testing.T) {
@@ -173,9 +176,9 @@ func TestComponentController(t *testing.T) {
 		errGetImage := cl.Get(context.Background(), types.NamespacedName{Namespace: Namespace, Name: Name + "-output"}, is)
 		require.NoError(t, errGetImage, "output imagestream is not created")
 
-		isRuntime := &imagev1.ImageStream{}
-		errGetRuntimeImage := cl.Get(context.Background(), types.NamespacedName{Namespace: Namespace, Name: Name + "-runtime"}, isRuntime)
-		require.NoError(t, errGetRuntimeImage, "runtime imagestream is not created")
+		isBuilder := &imagev1.ImageStream{}
+		errGetBuilderImage := cl.Get(context.Background(), types.NamespacedName{Namespace: Namespace, Name: Name + "-runtime"}, isBuilder)
+		require.NoError(t, errGetBuilderImage, "builder imagestream is not created")
 
 		bc := &buildv1.BuildConfig{}
 		errGetBC := cl.Get(context.Background(), types.NamespacedName{Namespace:Namespace, Name: Name  + "-bc"}, bc)


### PR DESCRIPTION
fixes https://jira.coreos.com/browse/ODC-133
if runtime image is found on openshift namespace use it, instead of pulling from docker hub.
For unit-test i took ex on Dipak work on toolchain-operator
