### PR TITLE
Dockerfile to create operator registry

### DIFF
--- a/test/olm/Dockerfile
+++ b/test/olm/Dockerfile
@@ -1,0 +1,7 @@
+FROM quay.io/openshift/origin-operator-registry:latest
+
+# The operator image location should be updated before copying.
+COPY manifests manifests
+
+RUN initializer
+CMD ["registry-server", "--termination-log=log.txt"]


### PR DESCRIPTION
Task: https://jira.coreos.com/browse/ODC-188

---

## Steps to verify operator registry

### 1. Install OLM (not required for OpenShift 4)

If you are using OpenShift 3, install OLM with this command:

```
kubectl create -f https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/olm.yaml 
```

Note: Alternately you can use `oc` command instead of `kubectl.`

### 2. Build and push the operator image to a public registry such as quay.io

Note: Instead of a public registry, the registry provided by OpenShift might work.

Checkout the `master` branch of [devopsconsole-operator](https://github.com/redhat-developer/devopsconsole-operator)

Then run these commands:

```
$ operator-sdk build quay.io/<username>/devopsconsole-operator
$ docker login -u <username> -p <password>  quay.io
$ docker push quay.io/<username>/devopsconsole-operator
```

When running the above command, substitute the `username` and `password` entries appropriately.

### 3. Update the CSV with the operator image location

Open this file
`manifests/devopsconsole/0.1.0/devopsconsole-operator.v0.1.0.clusterserviceversion.yaml` and change the image to point to the location pushed in the previous step.

Inside the file look for `image: REPLACE_IMAGE` and specify the image location.

### 4. Build the operator registry image

Now you are going to build the operator image using `test/olm/Dockerfile.`

```
docker build -f test/olm/Dockerfile . -t quay.io/<username>/operator-registry:0.1.0
docker push quay.io/<username>/operator-registry:0.1.0
```

When running the above command, substitute the `username` with your quay.io username.

### 5. Create CatalogSource and Subscription

Use this template to create a YAML file, say `cat-sub.yaml`:

```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: my-catalog
  namespace: olm
spec:
  sourceType: grpc
  image: quay.io/<username>/operator-registry:0.1.0
  displayName: Community Operators
  publisher: Red Hat
---
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: my-devopsconsole
  namespace: operators
spec:
  channel: alpha
  name: devopsconsole
  source: my-catalog
  sourceNamespace: olm
```

Before applying the above file, point to the newly created operator registry image (substitute the `username` with your quay.io username).

Example:

```
kubectl apply -f cat-sub.yaml
```

### 6. Verify gitsources CRD presence

Check for the existence of a Custom Resource Definitions with the name as `gitsources.devopsconsole.openshift.io`

Run this command to list CRDs:

```
oc get crds
```
