### PR TITLE
setting up a basic e2e test to verify component CR get created

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ This repository was initially bootstrapped using [CoreOS operator](https://githu
 ```
 make build
 ```
+### Test
+* run unit test:
+```
+make test-unit
+```
+* run e2e test:
+For running e2e tests, have minishift started.
+```
+make e2e-local
+```
+> Note: e2e test will deploy operator in project `devconsole-e2e-test`, if your tests timeout and you wan to debug:
+> - oc project devconsole-e2e-test
+> - oc get deployment,pod
+> - oc logs pod/devopsconsole-operator-5b4bbc7d-4p7hr
+
 ## Deployment
 
 ### Set up Minishift (one-off)

--- a/deploy/test/operator_test.yaml
+++ b/deploy/test/operator_test.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: devopsconsole-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: devopsconsole-operator
+  template:
+    metadata:
+      labels:
+        name: devopsconsole-operator
+    spec:
+      serviceAccountName: devopsconsole-operator
+      containers:
+      - name: devopsconsole-operator
+        # Replace this with the built image name
+        image: 172.30.1.1:5000/devconsole-e2e-test/devopsconsole-operator:latest
+        command:
+        - devopsconsole-operator
+        imagePullPolicy: IfNotPresent # replace with IfNotPresent for local dev to avoid pulling image and use docker cached image
+        env:
+        - name: WATCH_NAMESPACE
+          value: ""
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPERATOR_NAME
+          value: "devopsconsole-operator"

--- a/deploy/test/operator_test.yaml
+++ b/deploy/test/operator_test.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
       - name: devopsconsole-operator
         # Replace this with the built image name
-        image: 172.30.1.1:5000/devconsole-e2e-test/devopsconsole-operator:latest
+        image: REPLACE_IMAGE
         command:
         - devopsconsole-operator
         imagePullPolicy: IfNotPresent # replace with IfNotPresent for local dev to avoid pulling image and use docker cached image

--- a/deploy/test/role_binding_test.yaml
+++ b/deploy/test/role_binding_test.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: devopsconsole-operator
-  namespace: devconsole-e2e-test
+  namespace: REPLACE_NAMESPACE
 roleRef:
   kind: ClusterRole
   name: devopsconsole-operator

--- a/deploy/test/role_binding_test.yaml
+++ b/deploy/test/role_binding_test.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: devopsconsole-operator
+subjects:
+- kind: ServiceAccount
+  name: devopsconsole-operator
+  namespace: devconsole-e2e-test
+roleRef:
+  kind: ClusterRole
+  name: devopsconsole-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/make/test.mk
+++ b/make/test.mk
@@ -130,7 +130,6 @@ e2e-cleanup:
 		TEST_NAMESPACE_TEMP:=$(TEST_NAMESPACE_TEMP); \
 	fi
 	@-oc login -u system:admin
-	@-oc delete namespace $(TEST_NAMESPACE_TEMP)
 	@-oc delete -f deploy/crds/devopsconsole_v1alpha1_component_crd.yaml
 	@-oc delete -f deploy/service_account.yaml --namespace $(TEST_NAMESPACE_TEMP)
 	@-oc delete -f deploy/role.yaml --namespace $(TEST_NAMESPACE_TEMP)

--- a/make/test.mk
+++ b/make/test.mk
@@ -120,12 +120,12 @@ test-e2e: build build-image e2e-setup
 
 .PHONY: e2e-setup
 e2e-setup:  e2e-cleanup
-	oc new-project devconsole-e2e-test || true
+	@-oc new-project devconsole-e2e-test
 
 .PHONY: e2e-cleanup
 e2e-cleanup:
-	oc login -u system:admin
-	oc delete project devconsole-e2e-test || true
+	@-oc login -u system:admin
+	@-oc delete project devconsole-e2e-test
 
 #-------------------------------------------------------------------------------
 # Inspect coverage of unit tests, integration tests in either pure
@@ -345,3 +345,21 @@ CLEAN_TARGETS += clean-coverage-unit
 # Removes unit test coverage file
 clean-coverage-unit:
 	-@rm -f $(COV_PATH_UNIT)
+
+#-------------------------------------------------------------------------------
+# e2e test in dev mode
+#-------------------------------------------------------------------------------
+
+.PHONY: build-image-local
+build-image-local: e2e-setup
+	eval $$(minishift docker-env) && operator-sdk build $(shell minishift openshift registry)/devconsole-e2e-test/devopsconsole-operator
+
+.PHONY: e2e-local
+e2e-local: build-image-local
+	@-oc project devconsole-e2e-test
+	@-oc apply -f deploy/crds/devopsconsole_v1alpha1_component_crd.yaml
+	@-oc apply -f deploy/service_account.yaml --namespace devconsole-e2e-test
+	@-oc apply -f deploy/role.yaml --namespace devconsole-e2e-test
+	@-oc apply -f deploy/test/role_binding_test.yaml --namespace devconsole-e2e-test
+	@eval $$(minishift docker-env) && oc apply -f deploy/test/operator_test.yaml --namespace devconsole-e2e-test
+	@eval $$(minishift docker-env) && operator-sdk test local ./test/e2e --namespace devconsole-e2e-test --no-setup

--- a/make/test.mk
+++ b/make/test.mk
@@ -371,10 +371,23 @@ e2e-local: build-image-local
 	@-oc create -f $(CUR_DIR)/deploy/crds/devopsconsole_v1alpha1_component_crd.yaml
 	@-oc create -f $(CUR_DIR)/deploy/service_account.yaml --namespace $(TEST_NAMESPACE)
 	@-oc create -f $(CUR_DIR)/deploy/role.yaml --namespace $(TEST_NAMESPACE)
+ifeq ($(UNAME_S),Darwin)
+	@sed -i "" 's|REPLACE_NAMESPACE|$(TEST_NAMESPACE)|g' $(CUR_DIR)/deploy/test/role_binding_test.yaml
+else
 	@sed -i 's|REPLACE_NAMESPACE|$(TEST_NAMESPACE)|g' $(CUR_DIR)/deploy/test/role_binding_test.yaml
+endif
 	@-oc create -f $(CUR_DIR)/deploy/test/role_binding_test.yaml --namespace $(TEST_NAMESPACE)
+ifeq ($(UNAME_S),Darwin)
+	@sed -i "" 's|REPLACE_IMAGE|172.30.1.1:5000/$(TEST_NAMESPACE)/devopsconsole-operator:latest|g' $(CUR_DIR)/deploy/test/operator_test.yaml
+else
 	@sed -i 's|REPLACE_IMAGE|172.30.1.1:5000/$(TEST_NAMESPACE)/devopsconsole-operator:latest|g' $(CUR_DIR)/deploy/test/operator_test.yaml
+endif
 	@eval $$(minishift docker-env) && oc create -f $(CUR_DIR)/deploy/test/operator_test.yaml --namespace $(TEST_NAMESPACE)
+ifeq ($(UNAME_S),Darwin)
+	@sed -i "" 's|$(TEST_NAMESPACE)|REPLACE_NAMESPACE|g' $(CUR_DIR)/deploy/test/role_binding_test.yaml
+	@sed -i "" 's|172.30.1.1:5000/$(TEST_NAMESPACE)/devopsconsole-operator:latest|REPLACE_IMAGE|g' $(CUR_DIR)/deploy/test/operator_test.yaml
+else
 	@sed -i 's|$(TEST_NAMESPACE)|REPLACE_NAMESPACE|g' $(CUR_DIR)/deploy/test/role_binding_test.yaml
 	@sed -i 's|172.30.1.1:5000/$(TEST_NAMESPACE)/devopsconsole-operator:latest|REPLACE_IMAGE|g' $(CUR_DIR)/deploy/test/operator_test.yaml
+endif
 	@eval $$(minishift docker-env) && operator-sdk test local ./test/e2e --namespace $(TEST_NAMESPACE) --no-setup

--- a/make/test.mk
+++ b/make/test.mk
@@ -119,7 +119,7 @@ test-unit: prebuild-check $(SOURCES)
 ## Runs the e2e tests without coverage
 test-e2e: build build-image e2e-setup
 	$(call log-info,"Running E2E test: $@")
-	go test ./test/e2e/... -root=$(PWD) -kubeconfig=$(HOME)/.kube/config -globalMan deploy/test/global-manifests.yaml -namespacedMan deploy/test/namespace-manifests.yaml -v -parallel=1 -singleNamespace
+	go test ./test/e2e/... -root=$(PWD) -kubeconfig=$(HOME)/.kube/config -globalMan $(CUR_DIR)/deploy/test/global-manifests.yaml -namespacedMan $(CUR_DIR)/deploy/test/namespace-manifests.yaml -v -parallel=1 -singleNamespace
 .PHONY: e2e-setup
 e2e-setup: e2e-cleanup
 	@-oc new-project $(TEST_NAMESPACE)
@@ -130,11 +130,11 @@ e2e-cleanup:
 		TEST_NAMESPACE_TEMP:=$(TEST_NAMESPACE_TEMP); \
 	fi
 	@-oc login -u system:admin
-	@-oc delete -f deploy/crds/devopsconsole_v1alpha1_component_crd.yaml
-	@-oc delete -f deploy/service_account.yaml --namespace $(TEST_NAMESPACE_TEMP)
-	@-oc delete -f deploy/role.yaml --namespace $(TEST_NAMESPACE_TEMP)
-	@-oc delete -f deploy/test/role_binding_test.yaml --namespace $(TEST_NAMESPACE_TEMP)
-	@-oc delete -f deploy/test/operator_test.yaml --namespace $(TEST_NAMESPACE_TEMP)
+	@-oc delete -f $(CUR_DIR)/deploy/crds/devopsconsole_v1alpha1_component_crd.yaml
+	@-oc delete -f $(CUR_DIR)/deploy/service_account.yaml --namespace $(TEST_NAMESPACE_TEMP)
+	@-oc delete -f $(CUR_DIR)/deploy/role.yaml --namespace $(TEST_NAMESPACE_TEMP)
+	@-oc delete -f $(CUR_DIR)/deploy/test/role_binding_test.yaml --namespace $(TEST_NAMESPACE_TEMP)
+	@-oc delete -f $(CUR_DIR)/deploy/test/operator_test.yaml --namespace $(TEST_NAMESPACE_TEMP)
 	TEST_NAMESPACE_TEMP=$(TEST_NAMESPACE)
 
 #-------------------------------------------------------------------------------
@@ -368,13 +368,13 @@ build-image-local: e2e-setup
 e2e-local: build-image-local
 	@-oc login -u system:admin
 	@-oc project $(TEST_NAMESPACE)
-	@-oc create -f deploy/crds/devopsconsole_v1alpha1_component_crd.yaml
-	@-oc create -f deploy/service_account.yaml --namespace $(TEST_NAMESPACE)
-	@-oc create -f deploy/role.yaml --namespace $(TEST_NAMESPACE)
-	@sed -i 's|REPLACE_NAMESPACE|$(TEST_NAMESPACE)|g' deploy/test/role_binding_test.yaml
-	@-oc create -f deploy/test/role_binding_test.yaml --namespace $(TEST_NAMESPACE)
-	@sed -i 's|REPLACE_IMAGE|172.30.1.1:5000/$(TEST_NAMESPACE)/devopsconsole-operator:latest|g' deploy/test/operator_test.yaml
-	@eval $$(minishift docker-env) && oc create -f deploy/test/operator_test.yaml --namespace $(TEST_NAMESPACE)
-	@sed -i 's|$(TEST_NAMESPACE)|REPLACE_NAMESPACE|g' deploy/test/role_binding_test.yaml
-	@sed -i 's|172.30.1.1:5000/$(TEST_NAMESPACE)/devopsconsole-operator:latest|REPLACE_IMAGE|g' deploy/test/operator_test.yaml
+	@-oc create -f $(CUR_DIR)/deploy/crds/devopsconsole_v1alpha1_component_crd.yaml
+	@-oc create -f $(CUR_DIR)/deploy/service_account.yaml --namespace $(TEST_NAMESPACE)
+	@-oc create -f $(CUR_DIR)/deploy/role.yaml --namespace $(TEST_NAMESPACE)
+	@sed -i 's|REPLACE_NAMESPACE|$(TEST_NAMESPACE)|g' $(CUR_DIR)/deploy/test/role_binding_test.yaml
+	@-oc create -f $(CUR_DIR)/deploy/test/role_binding_test.yaml --namespace $(TEST_NAMESPACE)
+	@sed -i 's|REPLACE_IMAGE|172.30.1.1:5000/$(TEST_NAMESPACE)/devopsconsole-operator:latest|g' $(CUR_DIR)/deploy/test/operator_test.yaml
+	@eval $$(minishift docker-env) && oc create -f $(CUR_DIR)/deploy/test/operator_test.yaml --namespace $(TEST_NAMESPACE)
+	@sed -i 's|$(TEST_NAMESPACE)|REPLACE_NAMESPACE|g' $(CUR_DIR)/deploy/test/role_binding_test.yaml
+	@sed -i 's|172.30.1.1:5000/$(TEST_NAMESPACE)/devopsconsole-operator:latest|REPLACE_IMAGE|g' $(CUR_DIR)/deploy/test/operator_test.yaml
 	@eval $$(minishift docker-env) && operator-sdk test local ./test/e2e --namespace $(TEST_NAMESPACE) --no-setup

--- a/make/test.mk
+++ b/make/test.mk
@@ -87,7 +87,7 @@ ALL_PKGS_EXCLUDE_PATTERN = 'vendor\|app\|tool\/cli\|design\|client\|test'
 # This pattern excludes some folders from the go code analysis
 GOANALYSIS_PKGS_EXCLUDE_PATTERN="vendor|app|client|tool/cli"
 GOANALYSIS_DIRS=$(shell go list -f {{.Dir}} ./... | grep -v -E $(GOANALYSIS_PKGS_EXCLUDE_PATTERN))
-RANDOM := $(shell bash -c 'echo $$RANDOM')
+RANDOM := $(shell uuidgen)
 
 export TEST_NAMESPACE='devconsole-e2e-test-$(RANDOM)'
 export TEST_NAMESPACE_TEMP := ''

--- a/test/e2e/component_operator_test.go
+++ b/test/e2e/component_operator_test.go
@@ -1,0 +1,85 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
+	"github.com/redhat-developer/devopsconsole-operator/pkg/apis"
+	componentsv1alpha1 "github.com/redhat-developer/devopsconsole-operator/pkg/apis/devopsconsole/v1alpha1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"os"
+	"testing"
+	"time"
+)
+
+const (
+	retryInterval        = time.Second * 5
+	timeout              = time.Second * 60
+	cleanupRetryInterval = time.Second * 1
+	cleanupTimeout       = time.Second * 5
+)
+
+// ComponentTest does e2e test as per operator-sdk documentation
+// https://github.com/operator-framework/operator-sdk/blob/cc7b175/doc/test-framework/writing-e2e-tests.md
+func TestComponent(t *testing.T) {
+	// Register types with framework scheme
+	componentList := &componentsv1alpha1.ComponentList{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Component",
+			APIVersion: "devopsconsole.openshift.io/v1alpha1",
+		},
+	}
+	err := framework.AddToFrameworkScheme(apis.AddToScheme, componentList)
+	if err != nil {
+		t.Fatalf("failed to add custom resource scheme to framework: %v", err)
+	}
+	//// Setup the test context and resources
+	os.Setenv("TEST_NAMESPACE", "devconsole-e2e-test")
+	defer os.Unsetenv("TEST_NAMESPACE")
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup()
+	err = ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	require.NoError(t, err, "failed to initialize cluster resources")
+	t.Log("Initialized cluster resources")
+
+	namespace, err := ctx.GetNamespace()
+	require.NoError(t, err, "failed to get namespace where operator needs to run")
+
+	// get global framework variables
+	f := framework.Global
+	t.Log(fmt.Sprintf("namespace: %s", namespace))
+	// wait for component-operator to be ready
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "devopsconsole-operator", 1, retryInterval, timeout)
+	require.NoError(t, err, "failed while waiting for operator deployment")
+
+	t.Log("component-operator is ready and running state")
+
+	// create a Component custom resource
+	cr := &componentsv1alpha1.Component{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Component",
+			APIVersion: "devopsconsole.openshift.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: 		"mycomp",
+			Namespace:	namespace,
+		},
+		Spec: componentsv1alpha1.ComponentSpec{
+			BuildType: "nodejs",
+			Codebase: "https://github.com/nodeshift-starters/nodejs-rest-http-crud",
+		},
+	}
+	// use TestCtx's create helper to create the object and add a cleanup function for the new object
+	err = f.Client.Create(context.TODO(), cr, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	require.NoError(t, err, "failed to create custom resource of kind `Component`")
+
+	t.Run("retrieve component and verify related resources are created", func(t *testing.T) {
+		err = f.Client.Get(context.TODO(), types.NamespacedName{Name: "mycomp", Namespace: namespace}, cr)
+		require.NoError(t, err, "failed to retrieve custom resource of kind `Component`")
+		require.Equal(t, "https://github.com/nodeshift-starters/nodejs-rest-http-crud", cr.Spec.Codebase)
+		require.Equal(t, "nodejs", cr.Spec.BuildType)
+	})
+}

--- a/test/e2e/component_operator_test.go
+++ b/test/e2e/component_operator_test.go
@@ -3,16 +3,20 @@ package e2e
 import (
 	"context"
 	"fmt"
-	framework "github.com/operator-framework/operator-sdk/pkg/test"
-	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
-	"github.com/redhat-developer/devopsconsole-operator/pkg/apis"
-	componentsv1alpha1 "github.com/redhat-developer/devopsconsole-operator/pkg/apis/devopsconsole/v1alpha1"
-	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"os"
 	"testing"
 	"time"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
+
+	"github.com/redhat-developer/devopsconsole-operator/pkg/apis"
+	componentsv1alpha1 "github.com/redhat-developer/devopsconsole-operator/pkg/apis/devopsconsole/v1alpha1"
+
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (

--- a/test/e2e/component_operator_test.go
+++ b/test/e2e/component_operator_test.go
@@ -3,17 +3,16 @@ package e2e
 import (
 	"context"
 	"fmt"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
+	"github.com/redhat-developer/devopsconsole-operator/pkg/apis"
+	componentsv1alpha1 "github.com/redhat-developer/devopsconsole-operator/pkg/apis/devopsconsole/v1alpha1"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"os"
 	"testing"
 	"time"
-
-	framework "github.com/operator-framework/operator-sdk/pkg/test"
-	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
-
-	"github.com/redhat-developer/devopsconsole-operator/pkg/apis"
-	componentsv1alpha1 "github.com/redhat-developer/devopsconsole-operator/pkg/apis/devopsconsole/v1alpha1"
-
-	"github.com/stretchr/testify/require"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -26,9 +25,30 @@ const (
 	cleanupTimeout       = time.Second * 5
 )
 
-// ComponentTest does e2e test as per operator-sdk documentation
-// https://github.com/operator-framework/operator-sdk/blob/cc7b175/doc/test-framework/writing-e2e-tests.md
-func TestComponent(t *testing.T) {
+type ComponentTestSuite struct {
+	suite.Suite
+	namespace string
+	framework *framework.Framework
+	client    *corev1client.CoreV1Client
+	ctx       *framework.TestCtx
+}
+
+func (suite *ComponentTestSuite) SetupSuite() {
+	suite.framework = framework.Global
+
+	coreclient, err := corev1client.NewForConfig(framework.Global.KubeConfig)
+	if err != nil {
+		panic("failed to create new client")
+	}
+	suite.client = coreclient
+
+	suite.ctx = framework.NewTestCtx(suite.T())
+
+	namespace, err := suite.ctx.GetNamespace()
+	require.NoError(suite.T(), err, "failed to get namespace where operator needs to run")
+	suite.namespace = namespace
+	suite.T().Log(fmt.Sprintf("namespace: %s", suite.namespace))
+
 	// Register types with framework scheme
 	componentList := &componentsv1alpha1.ComponentList{
 		TypeMeta: metav1.TypeMeta{
@@ -36,30 +56,27 @@ func TestComponent(t *testing.T) {
 			APIVersion: "devopsconsole.openshift.io/v1alpha1",
 		},
 	}
-	err := framework.AddToFrameworkScheme(apis.AddToScheme, componentList)
+	err = framework.AddToFrameworkScheme(apis.AddToScheme, componentList)
 	if err != nil {
-		t.Fatalf("failed to add custom resource scheme to framework: %v", err)
+		suite.T().Fatalf("failed to add custom resource scheme to framework: %v", err)
 	}
 
-	defer os.Unsetenv("TEST_NAMESPACE")
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup()
-	err = ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
-	require.NoError(t, err, "failed to initialize cluster resources")
-	t.Log("Initialized cluster resources")
+	err = suite.ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: suite.ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	require.NoError(suite.T(), err, "failed to initialize cluster resources")
+	suite.T().Log("Initialized cluster resources")
 
-	namespace, err := ctx.GetNamespace()
-	require.NoError(t, err, "failed to get namespace where operator needs to run")
-
-	// get global framework variables
-	f := framework.Global
-	t.Log(fmt.Sprintf("namespace: %s", namespace))
 	// wait for component-operator to be ready
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "devopsconsole-operator", 1, retryInterval, timeout)
-	require.NoError(t, err, "failed while waiting for operator deployment")
+	err = e2eutil.WaitForDeployment(suite.T(), suite.framework.KubeClient, suite.namespace, "devopsconsole-operator", 1, retryInterval, timeout)
+	require.NoError(suite.T(), err, "failed while waiting for operator deployment")
 
-	t.Log("component-operator is ready and running state")
+	suite.T().Log("component-operator is ready and running state")
+}
 
+// ComponentTest does e2e test as per operator-sdk documentation
+// https://github.com/operator-framework/operator-sdk/blob/cc7b175/doc/test-framework/writing-e2e-tests.md
+func (suite *ComponentTestSuite) TestComponent() {
+
+	suite.T().Log(fmt.Sprintf("namespace: %s", suite.namespace))
 	// create a Component custom resource
 	cr := &componentsv1alpha1.Component{
 		TypeMeta: metav1.TypeMeta{
@@ -68,7 +85,7 @@ func TestComponent(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mycomp",
-			Namespace: namespace,
+			Namespace: suite.namespace,
 		},
 		Spec: componentsv1alpha1.ComponentSpec{
 			BuildType: "nodejs",
@@ -76,13 +93,29 @@ func TestComponent(t *testing.T) {
 		},
 	}
 	// use TestCtx's create helper to create the object and add a cleanup function for the new object
-	err = f.Client.Create(context.TODO(), cr, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
-	require.NoError(t, err, "failed to create custom resource of kind `Component`")
+	err := suite.framework.Client.Create(context.TODO(), cr, &framework.CleanupOptions{TestContext: suite.ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	require.NoError(suite.T(), err, "failed to create custom resource of kind `Component`")
 
-	t.Run("retrieve component and verify related resources are created", func(t *testing.T) {
-		err = f.Client.Get(context.TODO(), types.NamespacedName{Name: "mycomp", Namespace: namespace}, cr)
+	suite.T().Run("retrieve component and verify related resources are created", func(t *testing.T) {
+		err = suite.framework.Client.Get(context.TODO(), types.NamespacedName{Name: "mycomp", Namespace: suite.namespace}, cr)
 		require.NoError(t, err, "failed to retrieve custom resource of kind `Component`")
 		require.Equal(t, "https://github.com/nodeshift-starters/nodejs-rest-http-crud", cr.Spec.Codebase)
 		require.Equal(t, "nodejs", cr.Spec.BuildType)
 	})
+}
+
+func (suite *ComponentTestSuite) TearDownSuite() {
+	err := suite.client.Namespaces().Delete(suite.namespace, &metav1.DeleteOptions{})
+	if err != nil {
+		panic("failed to delete test namespace")
+	}
+
+	os.Unsetenv("TEST_NAMESPACE")
+	suite.ctx.Cleanup()
+
+	suite.T().Log("teardown complete")
+}
+
+func TestComponentTestSuite(t *testing.T) {
+	suite.Run(t, new(ComponentTestSuite))
 }

--- a/test/e2e/component_operator_test.go
+++ b/test/e2e/component_operator_test.go
@@ -3,16 +3,20 @@ package e2e
 import (
 	"context"
 	"fmt"
-	framework "github.com/operator-framework/operator-sdk/pkg/test"
-	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
-	"github.com/redhat-developer/devopsconsole-operator/pkg/apis"
-	componentsv1alpha1 "github.com/redhat-developer/devopsconsole-operator/pkg/apis/devopsconsole/v1alpha1"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
-	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"os"
 	"testing"
 	"time"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
+
+	"github.com/redhat-developer/devopsconsole-operator/pkg/apis"
+	componentsv1alpha1 "github.com/redhat-developer/devopsconsole-operator/pkg/apis/devopsconsole/v1alpha1"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -37,9 +41,7 @@ func (suite *ComponentTestSuite) SetupSuite() {
 	suite.framework = framework.Global
 
 	coreclient, err := corev1client.NewForConfig(framework.Global.KubeConfig)
-	if err != nil {
-		panic("failed to create new client")
-	}
+	require.NoError(suite.T(), err, "failed to create new client")
 	suite.client = coreclient
 
 	suite.ctx = framework.NewTestCtx(suite.T())
@@ -106,9 +108,7 @@ func (suite *ComponentTestSuite) TestComponent() {
 
 func (suite *ComponentTestSuite) TearDownSuite() {
 	err := suite.client.Namespaces().Delete(suite.namespace, &metav1.DeleteOptions{})
-	if err != nil {
-		panic("failed to delete test namespace")
-	}
+	require.NoError(suite.T(), err, "failed to delete namespace")
 
 	os.Unsetenv("TEST_NAMESPACE")
 	suite.ctx.Cleanup()

--- a/test/e2e/component_operator_test.go
+++ b/test/e2e/component_operator_test.go
@@ -28,7 +28,7 @@ func TestComponent(t *testing.T) {
 	// Register types with framework scheme
 	componentList := &componentsv1alpha1.ComponentList{
 		TypeMeta: metav1.TypeMeta{
-			Kind: "Component",
+			Kind:       "Component",
 			APIVersion: "devopsconsole.openshift.io/v1alpha1",
 		},
 	}
@@ -36,8 +36,7 @@ func TestComponent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to add custom resource scheme to framework: %v", err)
 	}
-	//// Setup the test context and resources
-	os.Setenv("TEST_NAMESPACE", "devconsole-e2e-test")
+
 	defer os.Unsetenv("TEST_NAMESPACE")
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
@@ -60,16 +59,16 @@ func TestComponent(t *testing.T) {
 	// create a Component custom resource
 	cr := &componentsv1alpha1.Component{
 		TypeMeta: metav1.TypeMeta{
-			Kind: "Component",
+			Kind:       "Component",
 			APIVersion: "devopsconsole.openshift.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: 		"mycomp",
-			Namespace:	namespace,
+			Name:      "mycomp",
+			Namespace: namespace,
 		},
 		Spec: componentsv1alpha1.ComponentSpec{
 			BuildType: "nodejs",
-			Codebase: "https://github.com/nodeshift-starters/nodejs-rest-http-crud",
+			Codebase:  "https://github.com/nodeshift-starters/nodejs-rest-http-crud",
 		},
 	}
 	// use TestCtx's create helper to create the object and add a cleanup function for the new object


### PR DESCRIPTION
fixed odc-132
This PR adds:
- a simple e2e test for deploying `devopsconsole-operator` and creating a component CR component
- add Makefile support for testing locally in dev mode (test are not run in container) for easy writing and debugging of the 2e2 tests