### PR TITLE
modify role for olm deployment

### DIFF
--- a/manifests/devopsconsole/0.1.0/devopsconsole-operator.v0.1.0.clusterserviceversion.yaml
+++ b/manifests/devopsconsole/0.1.0/devopsconsole-operator.v0.1.0.clusterserviceversion.yaml
@@ -81,6 +81,12 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
           - apps
           resources:
           - deployments
@@ -100,15 +106,24 @@ spec:
           - devopsconsole.openshift.io
           resources:
           - '*'
-          - components
           verbs:
           - '*'
         - apiGroups:
-          - components.devopsconsole.openshift.io
+          - image.openshift.io
           resources:
-          - '*'
+          - imagestreams
           verbs:
-          - '*'
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - build.openshift.io
+          resources:
+          - buildconfigs
+          verbs:
+          - create
+          - get
         serviceAccountName: devopsconsole-operator
     strategy: deployment
   installModes:

--- a/test/README.md
+++ b/test/README.md
@@ -23,3 +23,95 @@ make test-e2e
 This make target is building new docker image `$(DOCKER_REPO)/$(IMAGE_NAME):test`(e.g. `quay.io/openshiftio/devopsconsole-operator:test`) which is used in the operator's deployment manifests in e2e tests.
 
 Also remember that it uses the `system:admin` account for creating all required resources from `deploy/test` directory.
+
+## Steps to verify operator registry
+
+### 1. Install OLM (not required for OpenShift 4)
+
+If you are using OpenShift 3, install OLM with this command:
+
+```
+oc create -f https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/olm.yaml 
+```
+
+> NOTE: Alternately you can use `oc` command instead of `kubectl.`
+
+### 2. Build and push the operator image to a public registry such as quay.io
+
+Note: Instead of a public registry, the registry provided by OpenShift might work.
+
+Checkout the `master` branch of [devopsconsole-operator](https://github.com/redhat-developer/devopsconsole-operator)
+
+Then run these commands:
+
+```
+$ operator-sdk build quay.io/<username>/devopsconsole-operator
+$ docker login -u <username> -p <password>  quay.io
+$ docker push quay.io/<username>/devopsconsole-operator
+```
+> NOTE: make your repo public
+When running the above command, substitute the `username` and `password` entries appropriately.
+
+### 3. Update the CSV with the operator image location
+
+Open this file
+`manifests/devopsconsole/0.1.0/devopsconsole-operator.v0.1.0.clusterserviceversion.yaml` and change the image to point to the location pushed in the previous step.
+
+Inside the file look for `image: REPLACE_IMAGE` and specify the image location.
+
+### 4. Build the operator registry image
+
+Now you are going to build the operator image using `test/olm/Dockerfile.`
+
+```
+docker build -f test/olm/Dockerfile . -t quay.io/<username>/operator-registry:0.1.0
+docker push quay.io/<username>/operator-registry:0.1.0
+```
+
+When running the above command, substitute the `username` with your quay.io username.
+
+### 5. Create CatalogSource and Subscription
+
+Use this template to create a YAML file, say `cat-sub.yaml`:
+
+```
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: my-catalog
+  namespace: olm
+spec:
+  sourceType: grpc
+  image: quay.io/<username>/operator-registry:0.1.0
+  displayName: Community Operators
+  publisher: Red Hat
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: my-devopsconsole
+  namespace: operators
+spec:
+  channel: alpha
+  name: devopsconsole
+  source: my-catalog
+  sourceNamespace: olm
+```
+
+Before applying the above file, point to the newly created operator registry image (substitute the `username` with your quay.io username).
+
+Example:
+
+```
+oc apply -f cat-sub.yaml
+```
+
+### 6. Verify gitsources CRD presence
+
+Check for the existence of a Custom Resource Definitions with the name as `gitsources.devopsconsole.openshift.io`
+
+Run this command to list CRDs:
+
+```
+oc get crds
+```


### PR DESCRIPTION
@baijum @Avni-Sharma Following your PR I think we need to update the clusterrole
With those changes I can now create a component via UI:
![k8XkTaeA](https://user-images.githubusercontent.com/1395710/54771056-c9c19d00-4c04-11e9-8e07-dcb2120eaaa4.png)
with following content:
```
apiVersion: devopsconsole.openshift.io/v1alpha1
kind: Component
metadata:
  creationTimestamp: '2019-03-21T17:04:47Z'
  generation: 1
  name: test-corinne
  namespace: default
  resourceVersion: '13534'
  selfLink: >-
    /apis/devopsconsole.openshift.io/v1alpha1/namespaces/default/components/test-corinne
  uid: 6ea2a3de-4bfb-11e9-a949-08002790bfac
spec:
  buildType: nodejs
  codebase: 'https://github.com/nodeshift-starters/nodejs-rest-http-crud'
```
also visible in command line:
```
oc project default
oc get component,bc,is,build 
NAME                                                AGE
component.devopsconsole.openshift.io/test-corinne   3m

NAME                                             TYPE      FROM         LATEST
buildconfig.build.openshift.io/test-corinne-bc   Source    Git@master   1

NAME                                                 DOCKER REPO                                   TAGS      UPDATED
imagestream.image.openshift.io/test-corinne-output   172.30.1.1:5000/default/test-corinne-output

NAME                                         TYPE      FROM          STATUS    STARTED         DURATION
build.build.openshift.io/test-corinne-bc-1   Source    Git@afc0f38   Running   3 minutes ago
```
you can see the controller was able to add, imagestream and buildconfig.